### PR TITLE
Configure clang-tidy so braces are always added for do/for/if/while

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,8 +34,6 @@ CheckOptions:
     value: '1'
   - key:   modernize-use-default-member-init.UseAssignment
     value: 1
-  - key:   readability-braces-around-statements.ShortStatementLines
-    value: '4'
   - key:   readability-identifier-naming.ClassCase
     value: CamelCase
   - key:   readability-identifier-naming.ClassMemberCase

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -33,8 +33,9 @@ int main(int argc, char *argv[])
     Gio::init();
 
     std::optional<Arguments> arguments = Arguments::parse(argc, argv, std::cout);
-    if (!arguments)
+    if (!arguments) {
         return EXIT_FAILURE;
+    }
 
     if (arguments->print_version_and_exit) {
         std::cout << Glib::get_prgname() << " " << UserIdentificationManager::Common::VERSION

--- a/src/cli/run.cpp
+++ b/src/cli/run.cpp
@@ -82,8 +82,9 @@ namespace UserIdentificationManager::Cli
             if (enabled_sources.empty()) {
                 std::cout << "  None\n";
             } else {
-                for (const Glib::ustring &source : enabled_sources)
+                for (const Glib::ustring &source : enabled_sources) {
                     std::cout << "  " << source << '\n';
+                }
             }
 
             std::cout << "Disabled sources:\n";
@@ -91,8 +92,9 @@ namespace UserIdentificationManager::Cli
             if (disabled_sources.empty()) {
                 std::cout << "  None\n";
             } else {
-                for (const Glib::ustring &source : disabled_sources)
+                for (const Glib::ustring &source : disabled_sources) {
                     std::cout << "  " << source << '\n';
+                }
             }
 
             return true;
@@ -125,17 +127,23 @@ namespace UserIdentificationManager::Cli
 
     int run(const Glib::RefPtr<ManagerProxy> &manager_proxy, const Arguments &arguments)
     {
-        if (arguments.print_identified_users)
-            if (!print_identified_users(manager_proxy))
+        if (arguments.print_identified_users) {
+            if (!print_identified_users(manager_proxy)) {
                 return EXIT_FAILURE;
+            }
+        }
 
-        if (arguments.print_sources)
-            if (!print_sources(manager_proxy))
+        if (arguments.print_sources) {
+            if (!print_sources(manager_proxy)) {
                 return EXIT_FAILURE;
+            }
+        }
 
-        if (arguments.monitor)
-            if (!monitor_until_ctrl_c(manager_proxy))
+        if (arguments.monitor) {
+            if (!monitor_until_ctrl_c(manager_proxy)) {
                 return EXIT_FAILURE;
+            }
+        }
 
         return EXIT_SUCCESS;
     }

--- a/src/common/scoped_temp_file.cpp
+++ b/src/common/scoped_temp_file.cpp
@@ -20,8 +20,9 @@ namespace
     {
         g_autofree char *path = nullptr;
         int fd = g_file_open_tmp(nullptr, &path, nullptr);
-        if (fd == -1)
+        if (fd == -1) {
             throw std::runtime_error("Failed to create temporary file");
+        }
 
         ssize_t bytes_written = write(fd, content.data(), content.size());
         close(fd);
@@ -43,7 +44,8 @@ namespace UserIdentificationManager::Common
 
     ScopedTempFile::~ScopedTempFile()
     {
-        if (!path_.empty())
+        if (!path_.empty()) {
             remove(path_.c_str());
+        }
     }
 }

--- a/src/daemon/configuration.cpp
+++ b/src/daemon/configuration.cpp
@@ -47,8 +47,9 @@ namespace UserIdentificationManager::Daemon
         } catch (const Glib::Error &e) {
             bool file_does_not_exist = e.matches(G_FILE_ERROR, Glib::FileError::NO_SUCH_ENTITY);
 
-            if (!file_does_not_exist)
+            if (!file_does_not_exist) {
                 g_warning("Failed to load %s: %s", file_name.c_str(), e.what().c_str());
+            }
 
             return config;
         }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -46,8 +46,9 @@ namespace UserIdentificationManager::Daemon
 
     int Daemon::run()
     {
-        if (!register_signal_handlers())
+        if (!register_signal_handlers()) {
             return EXIT_FAILURE;
+        }
 
         dbus_service_.own_name();
 
@@ -86,8 +87,9 @@ namespace UserIdentificationManager::Daemon
 
         bool success = sigint_source_id_ != 0 && sigterm_source_id_ != 0 && sighup_source_id_ != 0;
 
-        if (!success)
+        if (!success) {
             unregister_signal_handlers();
+        }
 
         return success;
     }

--- a/src/daemon/dbus_service.cpp
+++ b/src/daemon/dbus_service.cpp
@@ -33,8 +33,9 @@ namespace UserIdentificationManager::Daemon
 
     void DBusService::own_name()
     {
-        if (connection_id_ != 0)
+        if (connection_id_ != 0) {
             return;
+        }
 
         connection_id_ = Gio::DBus::own_name(Gio::DBus::BUS_TYPE_SYSTEM,
                                              Common::DBus::MANAGER_SERVICE_NAME,
@@ -45,8 +46,9 @@ namespace UserIdentificationManager::Daemon
 
     void DBusService::unown_name()
     {
-        if (connection_id_ == 0)
+        if (connection_id_ == 0) {
             return;
+        }
 
         manager_.stop_listening_for_user_identified();
 
@@ -57,8 +59,9 @@ namespace UserIdentificationManager::Daemon
     void DBusService::bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> &connection,
                                    const Glib::ustring & /*name*/)
     {
-        if (manager_.register_object(connection, Common::DBus::MANAGER_OBJECT_PATH) == 0)
+        if (manager_.register_object(connection, Common::DBus::MANAGER_OBJECT_PATH) == 0) {
             main_loop_->quit();
+        }
 
         manager_.start_listening_for_user_identified();
     }
@@ -101,8 +104,9 @@ namespace UserIdentificationManager::Daemon
     {
         std::vector<std::tuple<Glib::ustring, guint16>> result;
 
-        for (const IdSource::IdentifiedUser &user : id_source_group_.identified_users())
+        for (const IdSource::IdentifiedUser &user : id_source_group_.identified_users()) {
             result.emplace_back(user.user_identification_id, user.seat_id);
+        }
 
         invocation.ret(result);
     }
@@ -112,11 +116,13 @@ namespace UserIdentificationManager::Daemon
         std::vector<Glib::ustring> enabled;
         std::vector<Glib::ustring> disabled;
 
-        for (const std::string &name : id_source_group_.enabled_names())
+        for (const std::string &name : id_source_group_.enabled_names()) {
             enabled.emplace_back(name);
+        }
 
-        for (const std::string &name : id_source_group_.disabled_names())
+        for (const std::string &name : id_source_group_.disabled_names()) {
             disabled.emplace_back(name);
+        }
 
         invocation.ret(enabled, disabled);
     }

--- a/src/daemon/id_source.cpp
+++ b/src/daemon/id_source.cpp
@@ -49,8 +49,9 @@ namespace UserIdentificationManager::Daemon
 
     void IdSource::user_identified(const IdentifiedUser &identified_user) const
     {
-        if (listener_)
+        if (listener_) {
             listener_->user_identified(identified_user);
+        }
     }
 
     IdSource::Group::Group() : Group(create_sources())
@@ -59,17 +60,20 @@ namespace UserIdentificationManager::Daemon
 
     IdSource::Group::Group(Sources &&sources) : sources_(std::move(sources))
     {
-        for (auto &source : sources_)
+        for (auto &source : sources_) {
             source->set_listener(this);
+        }
     }
 
     std::vector<std::string> IdSource::Group::enabled_names() const
     {
         std::vector<std::string> names;
 
-        for (auto &source : sources_)
-            if (source->enabled())
+        for (auto &source : sources_) {
+            if (source->enabled()) {
                 names.emplace_back(source->name());
+            }
+        }
 
         return names;
     }
@@ -78,23 +82,27 @@ namespace UserIdentificationManager::Daemon
     {
         std::vector<std::string> names;
 
-        for (auto &source : sources_)
-            if (!source->enabled())
+        for (auto &source : sources_) {
+            if (!source->enabled()) {
                 names.emplace_back(source->name());
+            }
+        }
 
         return names;
     }
 
     void IdSource::Group::enable_all() const
     {
-        for (auto &source : sources_)
+        for (auto &source : sources_) {
             source->enable();
+        }
     }
 
     void IdSource::Group::disable_all() const
     {
-        for (auto &source : sources_)
+        for (auto &source : sources_) {
             source->disable();
+        }
     }
 
     void IdSource::Group::enable(const std::vector<std::string> &names) const
@@ -109,10 +117,11 @@ namespace UserIdentificationManager::Daemon
         for (const std::string &name : names) {
             IdSource *source = find_source(name);
 
-            if (source)
+            if (source) {
                 source->enable();
-            else
+            } else {
                 g_warning("Can not enable \"%s\", unknown source", name.c_str());
+            }
         }
     }
 
@@ -127,8 +136,9 @@ namespace UserIdentificationManager::Daemon
                   identified_user.user_identification_id.c_str(),
                   identified_user.seat_id);
 
-        if (identified_users_.size() >= MAX_SAVED_IDENTIFIED_USERS)
+        if (identified_users_.size() >= MAX_SAVED_IDENTIFIED_USERS) {
             identified_users_.pop_front();
+        }
 
         identified_users_.push_back(identified_user);
 
@@ -137,10 +147,11 @@ namespace UserIdentificationManager::Daemon
 
     IdSource *IdSource::Group::find_source(const std::string &name) const
     {
-        for (auto &source : sources_)
-            if (g_ascii_strcasecmp(source->name().c_str(), name.c_str()) == 0)
+        for (auto &source : sources_) {
+            if (g_ascii_strcasecmp(source->name().c_str(), name.c_str()) == 0) {
                 return source.get();
-
+            }
+        }
         return nullptr;
     }
 }

--- a/src/daemon/id_sources/mass_storage_device_id_source.cpp
+++ b/src/daemon/id_sources/mass_storage_device_id_source.cpp
@@ -30,16 +30,18 @@ namespace UserIdentificationManager::Daemon
         {
             std::ifstream stream(path);
 
-            if (!stream.is_open())
+            if (!stream.is_open()) {
                 return {};
+            }
 
             std::vector<std::string> lines;
 
             for (unsigned int i = 0; i < num_lines; i++) {
                 std::string line;
 
-                if (!std::getline(stream, line))
+                if (!std::getline(stream, line)) {
                     return {};
+                }
 
                 lines.emplace_back(std::move(line));
             }
@@ -54,10 +56,11 @@ namespace UserIdentificationManager::Daemon
 
         bool string_is_numeric(const std::string &str)
         {
-            for (char c : str)
-                if (c < '0' || c > '9')
+            for (char c : str) {
+                if (c < '0' || c > '9') {
                     return false;
-
+                }
+            }
             return true;
         }
     }
@@ -69,8 +72,9 @@ namespace UserIdentificationManager::Daemon
 
     void MassStorageDeviceIdSource::enable()
     {
-        if (enabled())
+        if (enabled()) {
             return;
+        }
 
         set_enabled(true);
 
@@ -85,8 +89,9 @@ namespace UserIdentificationManager::Daemon
 
     void MassStorageDeviceIdSource::disable()
     {
-        if (!enabled())
+        if (!enabled()) {
             return;
+        }
 
         file_monitors_.clear();
 
@@ -100,16 +105,18 @@ namespace UserIdentificationManager::Daemon
     {
         std::vector<Glib::RefPtr<Gio::Mount>> mounts = volume_monitor_->get_mounts();
 
-        for (auto &mount : mounts)
+        for (auto &mount : mounts) {
             mount_added(mount);
+        }
     }
 
     void MassStorageDeviceIdSource::mount_added(const Glib::RefPtr<Gio::Mount> &mount)
     {
         Glib::RefPtr<Gio::File> file = mount->get_root()->get_child(USER_ID_FILE_NAME);
 
-        if (!file->query_exists())
+        if (!file->query_exists()) {
             return;
+        }
 
         start_monitoring_file(file);
         read_file_and_notify(file->get_path());
@@ -141,16 +148,18 @@ namespace UserIdentificationManager::Daemon
                                                  const Glib::RefPtr<Gio::File> & /*other_file*/,
                                                  Gio::FileMonitorEvent event) const
     {
-        if (event == Gio::FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
+        if (event == Gio::FILE_MONITOR_EVENT_CHANGES_DONE_HINT) {
             read_file_and_notify(file->get_path());
+        }
     }
 
     void MassStorageDeviceIdSource::read_file_and_notify(const std::string &path) const
     {
         std::optional<IdentifiedUser> identified_user = Parser::read_file(path);
 
-        if (!identified_user)
+        if (!identified_user) {
             return;
+        }
 
         user_identified(*identified_user);
     }

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -34,8 +34,9 @@ int main(int argc, char *argv[])
     Gio::init();
 
     std::optional<Arguments> arguments = Arguments::parse(argc, argv, std::cout);
-    if (!arguments)
+    if (!arguments) {
         return EXIT_FAILURE;
+    }
 
     if (arguments->print_version_and_exit) {
         std::cout << Glib::get_prgname() << " " << UserIdentificationManager::Common::VERSION

--- a/src/daemon/pcsc_context.cpp
+++ b/src/daemon/pcsc_context.cpp
@@ -188,9 +188,9 @@ namespace UserIdentificationManager::Daemon
             //       - "3.1.3.2.3.2  Contactless Storage Cards" in
             //         https://muscle.apdu.fr/www.pcscworkgroup.com/PCSC/V2/pcsc3_v2.01.09.pdf .
             //       - https://en.wikipedia.org/wiki/Answer_to_reset
-            if (state.cbAtr > 5)
+            if (state.cbAtr > 5) {
                 return state.rgbAtr[5] == 0x4f;
-
+            }
             return false;
         }
 

--- a/src/daemon/unit_tests/arguments_test.cpp
+++ b/src/daemon/unit_tests/arguments_test.cpp
@@ -28,8 +28,9 @@ namespace UserIdentificationManager::Daemon
 
             argv.reserve(argv_strs.size());
 
-            for (auto &argv_str : argv_strs)
+            for (auto &argv_str : argv_strs) {
                 argv.push_back(argv_str.data());
+            }
 
             return Arguments::parse(argv.size(), argv.data(), output);
         }

--- a/src/daemon/unit_tests/id_source_test.cpp
+++ b/src/daemon/unit_tests/id_source_test.cpp
@@ -130,8 +130,9 @@ namespace UserIdentificationManager::Daemon
                                 users1[i],
                                 users2[i]);
 
-                if (!result)
+                if (!result) {
                     return result;
+                }
             }
 
             return testing::AssertionSuccess();


### PR DESCRIPTION
We have said "strive to follow AUTOSAR C++14" and rule M6-3-1 and M6-4-1 says "The statement forming the body of a switch, while, do ... statement shall be a compound statement." and "An if ( condition ) construct shall be followed by a compound statement. The else keyword shall be followed by either a compound statement, or another if statement."

It adds a little bit of clutter and there are other checks for checking things that these rules are meant to prevent (e.g. wrongly written multi-line macros are caught by bugprone-multiple-statement-macro). But since it is mostly harmless and we have a way to enforce it with clang-tidy, do so.