### PR TITLE
Readme fixes and additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,31 @@ meson build
 ninja -C build
 ```
 
+Installing and Running
+======================
+
+After building, installation can be performed by running:
+
+```shell
+sudo ninja -C build install
+```
+
+By default this will install under `/usr/local`. To change this pass `--prefix` when invoking
+`meson` or `meson configure`, e.g. `meson build --prefix=/usr`.
+
+`systemctl daemon-reload` must be run for systemd to notice the newly installed service file. The
+service will now start when a D-Bus call is made to it on the system bus. It can also be started
+manually by running `systemctl start user-identification-manager`.
+
+It is possible to run the daemon directly from the build directory and on the session bus, which
+might facilitate testing and debugging during development. To do this run:
+
+```shell
+export DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
+```
+
+And then run the built daemon executable directly from the build directory.
+
 Running Tests
 =============
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A D-Bus signal, `UserIdentified`, is emitted when a user is identified. See the
 
 # Dependencies
 
-- gdbus-codegen-glibmm
+- [gdbus-codegen-glibmm](https://github.com/Pelagicore/gdbus-codegen-glibmm)
 - glibmm (2.56)
 - googletest (1.8.1, for tests, optional)
 - pcsc-lite (1.8.22, if built with smart card, SCARD, id source)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A D-Bus signal, `UserIdentified`, is emitted when a user is identified. See the
 
 # Dependencies
 
-- gdbus-codgen-glibmm
+- gdbus-codegen-glibmm
 - glibmm (2.56)
 - googletest (1.8.1, for tests, optional)
 - pcsc-lite (1.8.22, if built with smart card, SCARD, id source)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Smart Card Source (SCARD)
 -------------------------
 
 Extract identification from smart cards. Currently only extracts the UID (unique identifier) from
-contactless smarts cards that is then used as a means to identify a user.
+contactless smart cards that is then used as a means to identify a user.
 
 Configuration
 =============

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ meson test -C build
 
 "No tests defined." is printed if the required version of googletest could not be found.
 
+Code Checking
+=============
+
+[Clang-Format](https://clang.llvm.org/docs/ClangFormat.html) and
+[Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/) are used for code style checking and
+"linting". Clang's [static analyzer](https://clang-analyzer.llvm.org/) checks are run as part of
+[Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/) as well. A [script](tools/check) exists to
+simplify running these tools. After building, simply run:
+
+```shell
+tools/check . build
+```
+
+Note that different versions of `clang-format` and `clang-tidy` may give different results. See
+[tools/ci/Dockerfile](tools/ci/Dockerfile) for what versions are run in the
+[CI system](tools/ci).
+
+The [CI system](tools/ci) also makes sure that the code compiles without any warnings. To turn
+warnings into errors when building locally, pass `-Dwerror=true` when invoking `meson` or
+`meson configure`.
+
 Identification Sources
 ======================
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# User Identification Manager
+User Identification Manager
+===========================
 
 D-Bus service for identifying users from external sources in an automotive setting.
 
 A D-Bus signal, `UserIdentified`, is emitted when a user is identified. See the
 [D-Bus interface](data/com.luxoft.UserIdentificationManager.xml) for details.
 
-# Dependencies
+Dependencies
+============
 
 - [gdbus-codegen-glibmm](https://github.com/Pelagicore/gdbus-codegen-glibmm)
 - glibmm (2.56)
 - googletest (1.8.1, for tests, optional)
 - pcsc-lite (1.8.22, if built with smart card, SCARD, id source)
 
-# Building
+Building
+========
 
 [Meson](https://mesonbuild.com/) is used for building. To build simply run:
 
@@ -21,7 +24,8 @@ meson build
 ninja -C build
 ```
 
-# Running Tests
+Running Tests
+=============
 
 Tests can be run with:
 
@@ -31,14 +35,16 @@ meson test -C build
 
 "No tests defined." is printed if the required version of googletest could not be found.
 
-# Identification Sources
+Identification Sources
+======================
 
 What sources to include in the daemon can be changed with [build options](meson_options.txt). For
 example, to disable the mass storage device source run `meson build -Dmsd_id_source=false` when
 building. When the daemon starts it reads what sources to enable/disable from a
 [configuration file](#Configuration). All sources included when building are enabled by default.
 
-## Mass Storage Device Source (MSD)
+Mass Storage Device Source (MSD)
+--------------------------------
 
 Reads identification data from a file called `pelux-user-id` in the root of a mass storage device,
 e.g. a USB stick. Meant to be used for demonstration and testing purposes. The file must be formated
@@ -49,12 +55,14 @@ ID <numeric string>
 SEAT <hex value between 0x0 and 0xffff, must start with 0x>
 ```
 
-## Smart Card Source (SCARD)
+Smart Card Source (SCARD)
+-------------------------
 
 Extract identification from smart cards. Currently only extracts the UID (unique identifier) from
 contactless smarts cards that is then used as a means to identify a user.
 
-# Configuration
+Configuration
+=============
 
 The daemon reads configuration from `/etc/user-identification-manager.conf`. A default configuration
 will be used if the file does not exist. Another path can be used by passing the `-c`/`--config`
@@ -68,7 +76,8 @@ Content that corresponds to default configuration with comments explaining the v
 enable=
 ```
 
-# Command Line Interface
+Command Line Interface
+======================
 
 `uimcli` is a command line tool that can be used to debug and monitor the User Identification
 Manager daemon. Help summary:
@@ -88,7 +97,8 @@ Application Options:
   -m, --monitor              Monitor user identification events
 ```
 
-# License and Copyright
+License and Copyright
+=====================
 
 Copyright © 2019 Luxoft Sweden AB
 

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -1,0 +1,11 @@
+Testing Docker Image
+====================
+
+Local testing of the [Docker image](Dockerfile) used by the [Jenkinsfile](Jenkinsfile) can be
+performed by running the following in the project root directory:
+
+```shell
+$ name=$(basename $(pwd)) work_dir=/home/user/$name
+$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f tools/ci/Dockerfile -t $name .
+$ docker run -it --volume $(pwd):$work_dir --workdir=$work_dir $name
+```


### PR DESCRIPTION
Cherry picked from https://github.com/Pelagicore/template-dbus-service/pull/9 (and modified accordingly, i.e. `template-dbus-service` -> `user-identification-manager`, conflict resolution etc.).